### PR TITLE
Pare down to only setrounding method

### DIFF
--- a/src/SetRounding.jl
+++ b/src/SetRounding.jl
@@ -3,12 +3,12 @@ module SetRounding
 
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
-import Base:
-    RoundingMode, RoundNearest, RoundToZero, RoundUp, RoundDown, RoundFromZero,
-    RoundNearestTiesAway, RoundNearestTiesUp,
+import Base.Rounding:
     rounding, setrounding,
-    get_zero_subnormals, set_zero_subnormals
+    rounding_raw, setrounding_raw
 
+
+const Float32_64 = Union{Float32, Float64}
 
 let fenv_consts = Vector{Cint}(undef, 9)
     ccall(:jl_get_fenv_consts, Nothing, (Ptr{Cint},), fenv_consts)
@@ -44,117 +44,12 @@ function from_fenv(r::Integer)
     end
 end
 
-"""
-    setrounding(T, mode)
-Set the rounding mode of floating point type `T`, controlling the rounding of basic
-arithmetic functions ([`+`](@ref), [`-`](@ref), [`*`](@ref),
-[`/`](@ref) and [`sqrt`](@ref)) and type conversion. Other numerical
-functions may give incorrect or invalid values when using rounding modes other than the
-default `RoundNearest`.
-Note that this may affect other types, for instance changing the rounding mode of
-[`Float64`](@ref) will change the rounding mode of [`Float32`](@ref).
-See [`RoundingMode`](@ref) for available modes.
-!!! warning
-    This feature is still experimental, and may give unexpected or incorrect values.
-"""
-setrounding(T::Type, mode)
+setrounding_raw(::Type{<:Float32_64}, i::Integer) = ccall(:fesetround, Int32, (Int32,), i)
 
-"""
-    rounding(T)
-Get the current floating point rounding mode for type `T`, controlling the rounding of basic
-arithmetic functions ([`+`](@ref), [`-`](@ref), [`*`](@ref), [`/`](@ref)
-and [`sqrt`](@ref)) and type conversion.
-See [`RoundingMode`](@ref) for available modes.
-"""
-:rounding
+rounding_raw(::Type{<:Float32_64}) = ccall(:fegetround, Int32, ())
 
-setrounding_raw(::Type{<:Union{Float32,Float64}}, i::Integer) = ccall(:fesetround, Int32, (Int32,), i)
-rounding_raw(::Type{<:Union{Float32,Float64}}) = ccall(:fegetround, Int32, ())
+@noinline setrounding(::Type{T}, r::RoundingMode) where {T<:Float32_64} = setrounding_raw(T,to_fenv(r))
 
-@noinline setrounding(::Type{T}, r::RoundingMode) where {T<:Union{Float32,Float64}} = setrounding_raw(T,to_fenv(r))
-rounding(::Type{T}) where {T<:Union{Float32,Float64}} = from_fenv(rounding_raw(T))
-
-"""
-    setrounding(f::Function, T, mode)
-Change the rounding mode of floating point type `T` for the duration of `f`. It is logically
-equivalent to:
-    old = rounding(T)
-    setrounding(T, mode)
-    f()
-    setrounding(T, old)
-See [`RoundingMode`](@ref) for available rounding modes.
-!!! warning
-    This feature is still experimental, and may give unexpected or incorrect values. A
-    known problem is the interaction with compiler optimisations, e.g.
-        julia> setrounding(Float64,RoundDown) do
-                   1.1 + 0.1
-               end
-        1.2000000000000002
-    Here the compiler is *constant folding*, that is evaluating a known constant
-    expression at compile time, however the rounding mode is only changed at runtime, so
-    this is not reflected in the function result. This can be avoided by moving constants
-    outside the expression, e.g.
-        julia> x = 1.1; y = 0.1;
-        julia> setrounding(Float64,RoundDown) do
-                   x + y
-               end
-        1.2
-"""
-function setrounding(f::Function, ::Type{T}, rounding::RoundingMode) where T
-    old_rounding_raw = rounding_raw(T)
-    setrounding(T,rounding)
-    try
-        return f()
-    finally
-        setrounding_raw(T,old_rounding_raw)
-    end
-end
-
-
-# Should be equivalent to:
-#   setrounding(Float64,r) do
-#       convert(T,x)
-#   end
-# but explicit checks are currently quicker (~20x).
-# Assumes conversion is performed by rounding to nearest value.
-
-# To avoid ambiguous dispatch with methods in mpfr.jl:
-(::Type{T})(x::Real, r::RoundingMode) where {T<:AbstractFloat} = _convert_rounding(T,x,r)
-
-_convert_rounding(::Type{T}, x::Real, r::RoundingMode{:Nearest}) where {T<:AbstractFloat} = convert(T,x)
-function _convert_rounding(::Type{T}, x::Real, r::RoundingMode{:Down}) where T<:AbstractFloat
-    y = convert(T,x)
-    y > x ? prevfloat(y) : y
-end
-function _convert_rounding(::Type{T}, x::Real, r::RoundingMode{:Up}) where T<:AbstractFloat
-    y = convert(T,x)
-    y < x ? nextfloat(y) : y
-end
-function _convert_rounding(::Type{T}, x::Real, r::RoundingMode{:ToZero}) where T<:AbstractFloat
-    y = convert(T,x)
-    if x > 0.0
-        y > x ? prevfloat(y) : y
-    else
-        y < x ? nextfloat(y) : y
-    end
-end
-
-"""
-    set_zero_subnormals(yes::Bool) -> Bool
-If `yes` is `false`, subsequent floating-point operations follow rules for IEEE arithmetic
-on subnormal values ("denormals"). Otherwise, floating-point operations are permitted (but
-not required) to convert subnormal inputs or outputs to zero. Returns `true` unless
-`yes==true` but the hardware does not support zeroing of subnormal numbers.
-`set_zero_subnormals(true)` can speed up some computations on some hardware. However, it can
-break identities such as `(x-y==0) == (x==y)`.
-"""
-set_zero_subnormals(yes::Bool) = ccall(:jl_set_zero_subnormals,Int32,(Int8,),yes)==0
-
-"""
-    get_zero_subnormals() -> Bool
-Returns `false` if operations on subnormal floating-point values ("denormals") obey rules
-for IEEE arithmetic, and `true` if they might be converted to zeros.
-"""
-get_zero_subnormals() = ccall(:jl_get_zero_subnormals,Int32,())!=0
+rounding(::Type{T}) where {T<:Float32_64} = from_fenv(rounding_raw(T))
 
 end #module

--- a/src/SetRounding.jl
+++ b/src/SetRounding.jl
@@ -4,9 +4,7 @@ module SetRounding
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
 import Base.Rounding:
-    rounding, setrounding,
-    rounding_raw, setrounding_raw
-
+    setrounding
 
 const Float32_64 = Union{Float32, Float64}
 
@@ -46,10 +44,6 @@ end
 
 setrounding_raw(::Type{<:Float32_64}, i::Integer) = ccall(:fesetround, Int32, (Int32,), i)
 
-rounding_raw(::Type{<:Float32_64}) = ccall(:fegetround, Int32, ())
-
-@noinline setrounding(::Type{T}, r::RoundingMode) where {T<:Float32_64} = setrounding_raw(T,to_fenv(r))
-
-rounding(::Type{T}) where {T<:Float32_64} = from_fenv(rounding_raw(T))
+@noinline setrounding(::Type{T}, r::RoundingMode) where {T<:Float32_64} = setrounding_raw(T, to_fenv(r))
 
 end #module


### PR DESCRIPTION
There was a lot of duplication of things that are still in Base.
The only thing that is needed is `setrounding` for `Float64` and `Float32`.